### PR TITLE
Opinionated auto-formatting with Prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+    "trailingComma": "es5",
+    "singleQuote": true
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "esbenp.prettier-vscode"
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "format": "prettier --write '{src,public}/**/*.{js,css,html}'"
   },
   "eslintConfig": {
     "extends": "react-app"
@@ -32,5 +33,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "prettier": "^1.18.2"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -1,9 +1,9 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
     <!--
       Notice the use of %PUBLIC_URL% in the tag above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/src/App.js
+++ b/src/App.js
@@ -1,67 +1,68 @@
+import React from 'react';
+import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
-import React from 'react'
-import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
-import { useLocation} from "react-router";
+import CanvasContainer from './components/CanvasContainer';
+import './App.css';
 
-import CanvasContainer from './components/CanvasContainer'
-import './App.css'
-
-import {ExperimentList} from './experiments/'
-
+import { ExperimentList } from './experiments/';
 
 // TODO : Break this out into a view. Generate a TOC based on barrel?
 const Home = () => {
-
-    return (
-        <div>
-            <br/>
-            <h1>Experiments in</h1>
-            <h2>react-three-fiber</h2>
-            <h3>Locations follow this pattern</h3>
-            <code>/experiment/_name_</code>
-        </div>
-    )
+  return (
+    <div>
+      <br />
+      <h1>Experiments in</h1>
+      <h2>react-three-fiber</h2>
+      <h3>Locations follow this pattern</h3>
+      <code>/experiment/_name_</code>
+    </div>
+  );
 };
 
-const getNotFoundMarkup = (id) => {
-    return (
-        <div>
-            <br/>
-            <h1>Experiments in</h1>
-            <h2>react-three-fiber</h2>
-            <h3>Locations follow this pattern</h3>
-            <code>/experiment/_name_</code>
-            <br/><br/>
-            <h3 style={{color:'red'}}>Experiment <div style={{display:'inline', color:'white'}}>{id}</div> not found.</h3>
-            <br/>
-        </div>
-    )
-}
-
+const getNotFoundMarkup = id => {
+  return (
+    <div>
+      <br />
+      <h1>Experiments in</h1>
+      <h2>react-three-fiber</h2>
+      <h3>Locations follow this pattern</h3>
+      <code>/experiment/_name_</code>
+      <br />
+      <br />
+      <h3 style={{ color: 'red' }}>
+        Experiment <div style={{ display: 'inline', color: 'white' }}>{id}</div>{' '}
+        not found.
+      </h3>
+      <br />
+    </div>
+  );
+};
 
 const Experiment = () => {
+  let location = useLocation();
+  let id = location.pathname.split('/')[2];
+  let content = ExperimentList[id];
 
-    let location = useLocation();
-    let id = location.pathname.split('/')[2];
-    let content = ExperimentList[id];
-
-    let ExpRender = content ?
+  let ExpRender = content ? (
     <CanvasContainer>{content}</CanvasContainer>
-    : getNotFoundMarkup(id);
+  ) : (
+    getNotFoundMarkup(id)
+  );
 
-    return ExpRender
+  return ExpRender;
 };
 
 const App = () => {
   return (
     <div className="App">
-        <Router>
-            <Switch>
-                <Route path="/experiment" component={Experiment} />
-                <Route path="/" component={Home} />
-            </Switch>
-        </Router>
+      <Router>
+        <Switch>
+          <Route path="/experiment" component={Experiment} />
+          <Route path="/" component={Home} />
+        </Switch>
+      </Router>
     </div>
-  )
-}
-export default App
+  );
+};
+export default App;

--- a/src/components/CanvasContainer.js
+++ b/src/components/CanvasContainer.js
@@ -1,14 +1,16 @@
-import React from 'react'
-import { Canvas } from 'react-three-fiber'
+import React from 'react';
+import { Canvas } from 'react-three-fiber';
 
+const CanvasContainer = props => {
+  return (
+    <Canvas
+      style={{ background: '#777777' }}
+      shadowMap
+      camera={{ position: [0, 0, 10] }}
+    >
+      {props.children}
+    </Canvas>
+  );
+};
 
-const CanvasContainer = (props) => {
-
-    return (
-        <Canvas style={{ background: "#777777" }} shadowMap camera={{ position: [0, 0, 10] }}>
-            {props.children}
-        </Canvas>
-    )
-}
-
-export default CanvasContainer
+export default CanvasContainer;

--- a/src/experiments/cube_plus/index.js
+++ b/src/experiments/cube_plus/index.js
@@ -1,79 +1,89 @@
-import React, {useRef} from 'react'
+import React, { useRef } from 'react';
 import { useFrame } from 'react-three-fiber';
 
-
-
 const Thing = () => {
+  const cubeZero = useRef();
+  useFrame(() => (cubeZero.current.rotation.x += 0.04));
+  const cubeOne = useRef();
+  useFrame(
+    () => (cubeOne.current.rotation.x = cubeOne.current.rotation.y += 0.02)
+  );
+  const cubeTwo = useRef();
+  useFrame(
+    () => (cubeTwo.current.rotation.x = cubeTwo.current.rotation.y -= 0.02)
+  );
+  const cubes = useRef();
+  useFrame(() => (cubes.current.rotation.z -= 0.01));
 
-   const cubeZero = useRef();
-   useFrame(() => (cubeZero.current.rotation.x += 0.04));
-   const cubeOne = useRef();
-   useFrame(() => (cubeOne.current.rotation.x = cubeOne.current.rotation.y += 0.02));
-   const cubeTwo = useRef();
-   useFrame(() => (cubeTwo.current.rotation.x = cubeTwo.current.rotation.y -= 0.02));
-   const cubes = useRef();
-   useFrame(() => (cubes.current.rotation.z -= 0.01));
+  return (
+    <group>
+      <spotLight
+        color="#FFF"
+        intensity={0.75}
+        position={[-10, 35, 10]}
+        angle={0.53}
+        penumbra={0.75}
+        shadow-mapSize-width={2048}
+        shadow-mapSize-height={2048}
+        castShadow
+      />
 
-    return (
-        <group>
+      <spotLight
+        color="red"
+        intensity={0.25}
+        position={[0, 0, 50]}
+        angle={0.2}
+        penumbra={0.75}
+        shadow-mapSize-width={2048}
+        shadow-mapSize-height={2048}
+        castShadow
+      />
 
-            <spotLight
-                color="#FFF"
-                intensity={0.75}
-                position={[-10, 35, 10]}
-                angle={0.53}
-                penumbra={0.75}
-                shadow-mapSize-width={2048}
-                shadow-mapSize-height={2048}
-                castShadow
-            />
+      <group ref={cubes}>
+        <mesh
+          ref={cubeZero}
+          onClick={e => console.log('click')}
+          onPointerOver={e => console.log('hover')}
+          onPointerOut={e => console.log('unhover')}
+        >
+          <boxBufferGeometry attach="geometry" args={[1.0, 1.0, 1.0]} />
+          <meshPhongMaterial attach="material" color="#FF7744" />
+        </mesh>
+        <mesh
+          ref={cubeOne}
+          onClick={e => console.log('click')}
+          onPointerOver={e => console.log('hover')}
+          onPointerOut={e => console.log('unhover')}
+        >
+          <boxBufferGeometry attach="geometry" args={[2.5, 2.5, 2.5]} />
+          <meshPhongMaterial
+            attach="material"
+            color="#AAFFDD"
+            opacity={0.5}
+            transparent
+          />
+        </mesh>
+        <mesh
+          ref={cubeTwo}
+          onClick={e => console.log('click')}
+          onPointerOver={e => console.log('hover')}
+          onPointerOut={e => console.log('unhover')}
+        >
+          <boxBufferGeometry attach="geometry" args={[5, 5, 5]} />
+          <meshPhongMaterial
+            attach="material"
+            color="#AABBFF"
+            opacity={0.25}
+            transparent
+          />
+        </mesh>
+      </group>
+      <mesh receiveShadow position={[0, 0, -10]}>
+        <planeBufferGeometry attach="geometry" args={[1000, 1000]} />
+        <meshPhongMaterial attach="material" color="#555555" />
+      </mesh>
+    </group>
+  );
+};
 
-            <spotLight
-            color="red"
-            intensity={0.25}
-            position={[0, 0, 50]}
-            angle={0.2}
-            penumbra={0.75}
-            shadow-mapSize-width={2048}
-            shadow-mapSize-height={2048}
-            castShadow
-        />
-
-            <group ref={cubes}>
-                <mesh
-                    ref={cubeZero}
-                    onClick={e => console.log('click')}
-                    onPointerOver={e => console.log('hover')}
-                    onPointerOut={e => console.log('unhover')}>
-                    <boxBufferGeometry attach="geometry" args={[1.0, 1.0, 1.0]}/>
-                    <meshPhongMaterial attach="material" color="#FF7744"/>
-
-                </mesh>
-                <mesh
-                    ref={cubeOne}
-                    onClick={e => console.log('click')}
-                    onPointerOver={e => console.log('hover')}
-                    onPointerOut={e => console.log('unhover')}>
-                    <boxBufferGeometry attach="geometry" args={[2.5, 2.5, 2.5]} />
-                    <meshPhongMaterial attach="material" color="#AAFFDD" opacity={0.5} transparent/>
-
-                </mesh>
-                <mesh
-                    ref={cubeTwo}
-                    onClick={e => console.log('click')}
-                    onPointerOver={e => console.log('hover')}
-                    onPointerOut={e => console.log('unhover')}>
-                    <boxBufferGeometry attach="geometry" args={[5, 5, 5]} />
-                    <meshPhongMaterial attach="material" color="#AABBFF" opacity={0.25} transparent/>
-
-                </mesh>
-            </group>
-            <mesh receiveShadow position={[0,0,-10]}>
-                <planeBufferGeometry attach="geometry" args={[1000, 1000]} />
-                <meshPhongMaterial attach="material" color="#555555" />
-            </mesh>
-        </group>
-    )
-}
-
-export default Thing
+export default Thing;

--- a/src/experiments/cube_turrel/index.js
+++ b/src/experiments/cube_turrel/index.js
@@ -1,84 +1,103 @@
-import React, {useRef} from 'react'
+import React, { useRef } from 'react';
 import { useFrame } from 'react-three-fiber';
 
-
-const angToRad = (ang) => {
-    return ang * Math.PI/180;
-}
+const angToRad = ang => {
+  return (ang * Math.PI) / 180;
+};
 const Thing = () => {
+  const cubeZero = useRef();
+  useFrame(() => (cubeZero.current.rotation.x += 0.04));
+  const cubeOne = useRef();
+  useFrame(
+    () => (cubeOne.current.rotation.x = cubeOne.current.rotation.y += 0.02)
+  );
+  const cubeTwo = useRef();
+  useFrame(
+    () => (cubeTwo.current.rotation.x = cubeTwo.current.rotation.y -= 0.02)
+  );
+  const cubes = useRef();
+  useFrame(() => (cubes.current.rotation.z -= 0.01));
 
-   const cubeZero = useRef();
-   useFrame(() => (cubeZero.current.rotation.x += 0.04));
-   const cubeOne = useRef();
-   useFrame(() => (cubeOne.current.rotation.x = cubeOne.current.rotation.y += 0.02));
-   const cubeTwo = useRef();
-   useFrame(() => (cubeTwo.current.rotation.x = cubeTwo.current.rotation.y -= 0.02));
-   const cubes = useRef();
-   useFrame(() => (cubes.current.rotation.z -= 0.01));
+  return (
+    <group>
+      <spotLight
+        color="red"
+        intensity={1}
+        position={[0, 0, 2]}
+        angle={1.25}
+        penumbra={1}
+        shadow-mapSize-width={2048}
+        shadow-mapSize-height={2048}
+        castShadow
+      />
 
-    return (
-        <group>
+      <group ref={cubes}>
+        <mesh
+          castShadow
+          ref={cubeZero}
+          onClick={e => console.log('click')}
+          onPointerOver={e => console.log('hover')}
+          onPointerOut={e => console.log('unhover')}
+        >
+          <boxBufferGeometry attach="geometry" args={[1.0, 1.0, 1.0]} />
+          <meshPhongMaterial attach="material" color="#FF7744" />
+        </mesh>
+        <mesh
+          ref={cubeOne}
+          onClick={e => console.log('click')}
+          onPointerOver={e => console.log('hover')}
+          onPointerOut={e => console.log('unhover')}
+        >
+          <boxBufferGeometry attach="geometry" args={[2.5, 2.5, 2.5]} />
+          <meshPhongMaterial
+            attach="material"
+            color="#AAFFDD"
+            opacity={0.5}
+            transparent
+          />
+        </mesh>
+        <mesh
+          ref={cubeTwo}
+          onClick={e => console.log('click')}
+          onPointerOver={e => console.log('hover')}
+          onPointerOut={e => console.log('unhover')}
+        >
+          <boxBufferGeometry attach="geometry" args={[5, 5, 5]} />
+          <meshPhongMaterial
+            attach="material"
+            color="#AABBFF"
+            opacity={0.25}
+            transparent
+          />
+        </mesh>
+      </group>
+      <mesh
+        receiveShadow
+        position={[0, 0, -10]}
+        rotation={[0, angToRad(45), 0]}
+      >
+        <planeBufferGeometry attach="geometry" args={[1000, 1000]} />
+        <meshPhongMaterial attach="material" color="#555555" />
+      </mesh>
+      <mesh
+        receiveShadow
+        position={[0, 0, -10]}
+        rotation={[0, angToRad(-45), 0]}
+      >
+        <planeBufferGeometry attach="geometry" args={[1000, 1000]} />
+        <meshPhongMaterial attach="material" color="#555555" />
+      </mesh>
 
+      <mesh
+        receiveShadow
+        position={[0, -10, 0]}
+        rotation={[angToRad(-45), 0, 0]}
+      >
+        <planeBufferGeometry attach="geometry" args={[1000, 1000]} />
+        <meshPhongMaterial attach="material" color="#220000" />
+      </mesh>
+    </group>
+  );
+};
 
-
-            <spotLight
-                color="red"
-                intensity={1}
-                position={[0, 0, 2]}
-                angle={1.25}
-                penumbra={1}
-                shadow-mapSize-width={2048}
-                shadow-mapSize-height={2048}
-                castShadow
-            />
-
-            <group ref={cubes}>
-                <mesh
-                    castShadow
-                    ref={cubeZero}
-                    onClick={e => console.log('click')}
-                    onPointerOver={e => console.log('hover')}
-                    onPointerOut={e => console.log('unhover')}>
-                    <boxBufferGeometry attach="geometry" args={[1.0, 1.0, 1.0]}/>
-                    <meshPhongMaterial attach="material" color="#FF7744"/>
-
-                </mesh>
-                <mesh
-
-                    ref={cubeOne}
-                    onClick={e => console.log('click')}
-                    onPointerOver={e => console.log('hover')}
-                    onPointerOut={e => console.log('unhover')}>
-                    <boxBufferGeometry attach="geometry" args={[2.5, 2.5, 2.5]} />
-                    <meshPhongMaterial attach="material" color="#AAFFDD" opacity={0.5} transparent/>
-
-                </mesh>
-                <mesh
-                    ref={cubeTwo}
-                    onClick={e => console.log('click')}
-                    onPointerOver={e => console.log('hover')}
-                    onPointerOut={e => console.log('unhover')}>
-                    <boxBufferGeometry attach="geometry" args={[5, 5, 5]} />
-                    <meshPhongMaterial attach="material" color="#AABBFF" opacity={0.25} transparent/>
-
-                </mesh>
-            </group>
-            <mesh receiveShadow position={[0,0,-10]} rotation={[0,angToRad(45),0]}>
-                <planeBufferGeometry attach="geometry" args={[1000, 1000]} />
-                <meshPhongMaterial attach="material" color="#555555" />
-            </mesh>
-            <mesh receiveShadow position={[0,0,-10]} rotation={[0,angToRad(-45),0]}>
-                <planeBufferGeometry attach="geometry" args={[1000, 1000]} />
-                <meshPhongMaterial attach="material" color="#555555" />
-            </mesh>
-
-            <mesh receiveShadow position={[0,-10,0]} rotation={[angToRad(-45),0,0]}>
-                <planeBufferGeometry attach="geometry" args={[1000, 1000]} />
-                <meshPhongMaterial attach="material" color="#220000" />
-            </mesh>
-
-        </group>
-    )
-}
-
-export default Thing
+export default Thing;

--- a/src/experiments/index.js
+++ b/src/experiments/index.js
@@ -1,15 +1,14 @@
 // Barrel for Experiments
-import React from 'react'
-import SimpleCube from './simple_cube/'
-import CubeTwo from './cube_plus/'
-import TurrelCube from './cube_turrel/'
-
+import React from 'react';
+import SimpleCube from './simple_cube/';
+import CubeTwo from './cube_plus/';
+import TurrelCube from './cube_turrel/';
 
 export { SimpleCube, CubeTwo, TurrelCube };
 
 // Object to be used for route resolution
 export const ExperimentList = {
-    cube: <SimpleCube/>,
-    cube_two: <CubeTwo/>,
-    turrel_cube: <TurrelCube/>,
-}
+  cube: <SimpleCube />,
+  cube_two: <CubeTwo />,
+  turrel_cube: <TurrelCube />,
+};

--- a/src/experiments/simple_cube/index.js
+++ b/src/experiments/simple_cube/index.js
@@ -1,23 +1,23 @@
-import React, {useRef} from 'react'
+import React, { useRef } from 'react';
 import { useFrame } from 'react-three-fiber';
 
-
-
 const Thing = () => {
+  const meshRef = useRef();
+  useFrame(
+    () => (meshRef.current.rotation.x = meshRef.current.rotation.y += 0.02)
+  );
 
-   const meshRef = useRef();
-   useFrame(() => (meshRef.current.rotation.x = meshRef.current.rotation.y += 0.02));
+  return (
+    <mesh
+      ref={meshRef}
+      onClick={e => console.log('click')}
+      onPointerOver={e => console.log('hover')}
+      onPointerOut={e => console.log('unhover')}
+    >
+      <boxBufferGeometry attach="geometry" args={[5, 5, 5]} />
+      <meshNormalMaterial attach="material" />
+    </mesh>
+  );
+};
 
-    return (
-        <mesh
-            ref={meshRef}
-            onClick={e => console.log('click')}
-            onPointerOver={e => console.log('hover')}
-            onPointerOut={e => console.log('unhover')}>
-            <boxBufferGeometry attach="geometry" args={[5, 5, 5]} />
-            <meshNormalMaterial attach="material" />
-        </mesh>
-    )
-}
-
-export default Thing
+export default Thing;

--- a/src/index.css
+++ b/src/index.css
@@ -1,12 +1,12 @@
 * {
-    box-sizing: border-box;
-  }
+  box-sizing: border-box;
+}
 
-  html,
-  body,
-  #root {
-    width: 100%;
-    height: 100%;
-    margin: 0;
-    padding: 0;
-  }
+html,
+body,
+#root {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,4 @@ import ReactDOM from 'react-dom';
 import App from './App';
 import './index.css';
 
-ReactDOM.render(
-  <App />,
-  document.getElementById('root')
-);
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/src/shaders/AdditiveBlendingShader.js
+++ b/src/shaders/AdditiveBlendingShader.js
@@ -1,25 +1,25 @@
 export default {
-    uniforms: {
-      tDiffuse: { value: null },
-      tAdd: { value: null }
-    },
+  uniforms: {
+    tDiffuse: { value: null },
+    tAdd: { value: null },
+  },
 
-    vertexShader: [
-      'varying vec2 vUv;',
-      'void main() {',
-      'vUv = uv;',
-      'gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );',
-      '}'
-    ].join('\n'),
+  vertexShader: [
+    'varying vec2 vUv;',
+    'void main() {',
+    'vUv = uv;',
+    'gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );',
+    '}',
+  ].join('\n'),
 
-    fragmentShader: [
-      'uniform sampler2D tDiffuse;',
-      'uniform sampler2D tAdd;',
-      'varying vec2 vUv;',
-      'void main() {',
-      'vec4 color = texture2D( tDiffuse, vUv );',
-      'vec4 add = texture2D( tAdd, vUv );',
-      'gl_FragColor = color + add;',
-      '}'
-    ].join('\n')
-  }
+  fragmentShader: [
+    'uniform sampler2D tDiffuse;',
+    'uniform sampler2D tAdd;',
+    'varying vec2 vUv;',
+    'void main() {',
+    'vec4 color = texture2D( tDiffuse, vUv );',
+    'vec4 add = texture2D( tAdd, vUv );',
+    'gl_FragColor = color + add;',
+    '}',
+  ].join('\n'),
+};

--- a/src/shaders/VolumetricLightShader.js
+++ b/src/shaders/VolumetricLightShader.js
@@ -1,4 +1,4 @@
-import * as THREE from 'three'
+import * as THREE from 'three';
 
 export default {
   uniforms: {
@@ -8,12 +8,16 @@ export default {
     decay: { value: 0.95 },
     density: { value: 1.0 },
     weight: { value: 0.4 },
-    samples: { value: 50 }
+    samples: { value: 50 },
   },
 
-  vertexShader: ['varying vec2 vUv;', 'void main() {', 'vUv = uv;', 'gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );', '}'].join(
-    '\n'
-  ),
+  vertexShader: [
+    'varying vec2 vUv;',
+    'void main() {',
+    'vUv = uv;',
+    'gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );',
+    '}',
+  ].join('\n'),
 
   fragmentShader: [
     'varying vec2 vUv;',
@@ -44,6 +48,6 @@ export default {
     'illuminationDecay *= decay;',
     '}',
     'gl_FragColor = color * exposure;',
-    '}'
-  ].join('\n')
-}
+    '}',
+  ].join('\n'),
+};

--- a/src/shaders/index.js
+++ b/src/shaders/index.js
@@ -1,4 +1,4 @@
-import AdditiveBlendingShader from './AdditiveBlendingShader'
-import VolumetricLightShader from './VolumetricLightShader'
+import AdditiveBlendingShader from './AdditiveBlendingShader';
+import VolumetricLightShader from './VolumetricLightShader';
 
-export { AdditiveBlendingShader, VolumetricLightShader }
+export { AdditiveBlendingShader, VolumetricLightShader };


### PR DESCRIPTION
Adds `prettier` for minimal-config auto-formatting of code.

- Run `npm run format` to automatically reformat the entire codebase with prettier's rules
- Optionally install the VS Code extension (it should show up as a recommended extension) and tell it to auto-format on save for JS files