### PR TITLE
FEATURE // Simple table of contents, experiment metadata

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,9 +1,32 @@
 .App {
-  display: block;
+  display: flex;
+  flex-direction: column;
   text-align: center;
   background-color: #222;
   color: #fff;
   height: 100vh;
 
   font-family: Arial, Helvetica, sans-serif;
+}
+
+.App__Content {
+  flex-grow: 1;
+}
+
+.ExperimentLinks {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+}
+
+.ExperimentLinks__Link {
+  margin: 1rem 0.5rem;
+  text-decoration: none;
+  text-transform: uppercase;
+  color: #888;
+}
+
+.ExperimentLinks__Link.active {
+  color: #fff;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,68 +1,75 @@
 import React from 'react';
-import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
-import { useLocation } from 'react-router';
+import {
+  BrowserRouter as Router,
+  Route,
+  Switch,
+  NavLink,
+} from 'react-router-dom';
 
 import CanvasContainer from './components/CanvasContainer';
 import './App.css';
 
-import { ExperimentList } from './experiments/';
+import experiments from './experiments/';
 
-// TODO : Break this out into a view. Generate a TOC based on barrel?
-const Home = () => {
+const ExperimentLinks = ({ experiments }) => {
   return (
-    <div>
-      <br />
-      <h1>Experiments in</h1>
-      <h2>react-three-fiber</h2>
-      <h3>Locations follow this pattern</h3>
-      <code>/experiment/_name_</code>
+    <div className="ExperimentLinks">
+      {experiments.map(({ id, name }, index) => (
+        <NavLink
+          key={`experiment-link-${id}`}
+          className="ExperimentLinks__Link"
+          to={`/experiments/${id}`}
+        >
+          {name}
+        </NavLink>
+      ))}
     </div>
   );
 };
 
-const getNotFoundMarkup = id => {
+const NotFound = ({ id }) => {
   return (
-    <div>
-      <br />
-      <h1>Experiments in</h1>
-      <h2>react-three-fiber</h2>
-      <h3>Locations follow this pattern</h3>
-      <code>/experiment/_name_</code>
-      <br />
-      <br />
-      <h3 style={{ color: 'red' }}>
-        Experiment <div style={{ display: 'inline', color: 'white' }}>{id}</div>{' '}
-        not found.
-      </h3>
-      <br />
-    </div>
+    <h3 style={{ color: 'red' }}>
+      Experiment <div style={{ display: 'inline', color: 'white' }}>{id}</div>{' '}
+      not found.
+    </h3>
   );
 };
 
-const Experiment = () => {
-  let location = useLocation();
-  let id = location.pathname.split('/')[2];
-  let content = ExperimentList[id];
+const Experiment = ({ id }) => {
+  const experiment = experiments.find(e => e.id === id);
 
-  let ExpRender = content ? (
-    <CanvasContainer>{content}</CanvasContainer>
-  ) : (
-    getNotFoundMarkup(id)
+  if (!experiment) {
+    return <NotFound id={id} />;
+  }
+
+  const { component: Component } = experiment;
+
+  return (
+    <CanvasContainer>
+      <Component />
+    </CanvasContainer>
   );
-
-  return ExpRender;
 };
 
 const App = () => {
   return (
-    <div className="App">
-      <Router>
-        <Switch>
-          <Route path="/experiment" component={Experiment} />
-          <Route path="/" component={Home} />
-        </Switch>
-      </Router>
-    </div>
+    <Router>
+      <div className="App">
+        <br />
+        <h1>Experiments in</h1>
+        <h2>react-three-fiber</h2>
+        <ExperimentLinks experiments={experiments} />
+        <div className="App__Content">
+          <Switch>
+            <Route
+              path="/experiments/:id"
+              render={({ match }) => <Experiment id={match.params.id} />}
+            />
+          </Switch>
+        </div>
+      </div>
+    </Router>
   );
 };
 export default App;

--- a/src/experiments/cube_plus/index.js
+++ b/src/experiments/cube_plus/index.js
@@ -1,7 +1,7 @@
 import React, { useRef } from 'react';
 import { useFrame } from 'react-three-fiber';
 
-const Thing = () => {
+export const AnotherCubeExperiment = () => {
   const cubeZero = useRef();
   useFrame(() => (cubeZero.current.rotation.x += 0.04));
   const cubeOne = useRef();
@@ -86,4 +86,8 @@ const Thing = () => {
   );
 };
 
-export default Thing;
+export default {
+  id: 'cube_plus',
+  name: 'Another Cube',
+  component: AnotherCubeExperiment,
+};

--- a/src/experiments/cube_turrel/index.js
+++ b/src/experiments/cube_turrel/index.js
@@ -4,7 +4,8 @@ import { useFrame } from 'react-three-fiber';
 const angToRad = ang => {
   return (ang * Math.PI) / 180;
 };
-const Thing = () => {
+
+export const TurrelCubeExperiment = () => {
   const cubeZero = useRef();
   useFrame(() => (cubeZero.current.rotation.x += 0.04));
   const cubeOne = useRef();
@@ -100,4 +101,8 @@ const Thing = () => {
   );
 };
 
-export default Thing;
+export default {
+  id: 'cube_turrel',
+  name: 'Turrel Cube',
+  component: TurrelCubeExperiment,
+};

--- a/src/experiments/index.js
+++ b/src/experiments/index.js
@@ -1,14 +1,9 @@
 // Barrel for Experiments
-import React from 'react';
-import SimpleCube from './simple_cube/';
-import CubeTwo from './cube_plus/';
-import TurrelCube from './cube_turrel/';
-
-export { SimpleCube, CubeTwo, TurrelCube };
+import simpleCube from './simple_cube/';
+import anotherCube from './cube_plus/';
+import turrelCube from './cube_turrel/';
 
 // Object to be used for route resolution
-export const ExperimentList = {
-  cube: <SimpleCube />,
-  cube_two: <CubeTwo />,
-  turrel_cube: <TurrelCube />,
-};
+const experiments = [simpleCube, anotherCube, turrelCube];
+
+export default experiments;

--- a/src/experiments/simple_cube/index.js
+++ b/src/experiments/simple_cube/index.js
@@ -1,7 +1,7 @@
 import React, { useRef } from 'react';
 import { useFrame } from 'react-three-fiber';
 
-const Thing = () => {
+export const SimpleCubeExperiment = () => {
   const meshRef = useRef();
   useFrame(
     () => (meshRef.current.rotation.x = meshRef.current.rotation.y += 0.02)
@@ -20,4 +20,8 @@ const Thing = () => {
   );
 };
 
-export default Thing;
+export default {
+  id: 'simple_cube',
+  name: 'Simple Cube',
+  component: SimpleCubeExperiment,
+};


### PR DESCRIPTION
<p align="center">
<img width="500" alt="Screen Shot 2019-11-08 at 11 54 59 AM" src="https://user-images.githubusercontent.com/771197/68495680-af354600-021e-11ea-9647-af1c29b3d410.png">
</p>

Experiment exports now look like this (with room for additional metadata as you see fit):
```
export default {
  id: 'cube_plus',
  name: 'Another Cube',
  component: AnotherCubeExperiment,
};
```

This allows us to loop over all experiments and use `id` in the route, `name` in the display, and the `component` to do the actual rendering.

Experiment routes follow the pattern of `/experiments/:id`.  I'm currently rendering simple `NavLink`s on all pages, but obviously there's plenty of opportunity to refine the UI.  The experiment list should wrap as we add more, but eventually a pullout sidebar or similar might be better.