### PR TITLE
loaders // remove suspense from static model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,56 @@
 ## Purpose of this Repo
-Just a place to mess around with this tech. According to the developers R3F could be faster than standalone 3JS and has the benefit of modern React composition [and hooks](https://github.com/react-spring/react-three-fiber#hooks). Note also that this can be implemented for [React Native using expo](https://github.com/react-spring/react-three-fiber/blob/master/recipes.md#usage-with-react-native). Not sure if this implementation has any benefits over useing raw 3JS in that case -- again, other than the built in component. I believe that even with R3F you can manipulate lower level 3JS if needed. 
 
-![Sample Experiment Image](https://repository-images.githubusercontent.com/220111814/f8829700-0218-11ea-9ee4-b6a022be385d "R3F-POC")
+Just a place to mess around with this tech. According to the developers R3F could be faster than standalone 3JS and has the benefit of modern React composition [and hooks](https://github.com/react-spring/react-three-fiber#hooks). Note also that this can be implemented for [React Native using expo](https://github.com/react-spring/react-three-fiber/blob/master/recipes.md#usage-with-react-native). Not sure if this implementation has any benefits over useing raw 3JS in that case -- again, other than the built in component. I believe that even with R3F you can manipulate lower level 3JS if needed.
 
- 
+![Sample Experiment Image](https://repository-images.githubusercontent.com/220111814/f8829700-0218-11ea-9ee4-b6a022be385d 'R3F-POC')
+
 ## Navigating Experiments
 
 ### Location-based (URL) Navigation
+
 One the app is running you can navigate to experiments using the following location url pattern: `/experiments/_name-of-experiment_` (Eg. `http://localhost:3000/experiment/cube`).
 
 ### Adding Experiments
-* Experiments all live in the `src/experiments` directory
-  * _Add your experiment directory and have at it_
-* They are rolled up in a single barrel file (`index.js`) at the root of `/experiments`
-  * _Make sure to import and export your experiment here_
-* This barrel file also exports and object defining the enumeration of available experiments
-  * _Make sure to add your experiment to the object, the `key` will be used as the path, the value as the component to be displayed_
-* All experiments are wrapped in the same simple `<Canvas>` (defined by `CanvasContainer`).
 
+- Experiments all live in the `src/experiments` directory
+  - _Add your experiment directory and have at it_
+- They are rolled up in a single barrel file (`index.js`) at the root of `/experiments`
+  - _Make sure to import and export your experiment here_
+- This barrel file also exports and object defining the enumeration of available experiments
+  - _Make sure to add your experiment to the object, the `key` will be used as the path, the value as the component to be displayed_
+- All experiments are wrapped in the same simple `<Canvas>` (defined by `CanvasContainer`).
 
 ## How It's Made
 
 ### Create React App
+
 This project was bootstrapped with [Create React App](https://github.com/facebookincubator/create-react-app).<br/>
 You can find the most recent version of this guide [here](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md).
 
 ### React Three Fiber
+
 In addition to CRA, `react-spring` and `react-three-fiber` are in place.<br/>
 You can get the basics about it [here](https://github.com/react-spring/react-three-fiber#what-is-it)
 
+### ThreeJS
+
+Created by the illustrius Mr. Doob, ThreeJS is the JavaScript to WebGL renderer that R3F uses.
+You can get the fundamentals about it [here](https://threejsfundamentals.org/)
+
+### GLTF Models
+
+ThreeJS can load load a number of 3D model formats. The GLTF format is a _packed_ GLB along with its binaries/textires -- this makes things pretty easy, however for more control we would might do these at individual passes.
+Some utilities and model resources:
+
+- [GLTF Model Viewer](https://github.com/donmccurdy/three-gltf-viewer)
+- [Convert GLTF to GLB online](https://glb-packer.glitch.me/)
+- [Google's Poly Models](https://poly.google.com/)
+- [SketchFab Models](https://sketchfab.com/)
+
+---
+
 ### Setting up and Running
+
 The usual CRA scripts apply.
 
 `yarn start`

--- a/src/experiments/index.js
+++ b/src/experiments/index.js
@@ -3,6 +3,7 @@ import simpleCube from './simple_cube/';
 import anotherCube from './cube_plus/';
 import turrellCube from './cube_turrell/';
 import modelStatic from './model_static/';
+import modelSuspense from './model_suspense/';
 import modelAnimated from './model_animated/';
 
 // Object to be used for route resolution
@@ -11,6 +12,7 @@ const experiments = [
   anotherCube,
   turrellCube,
   modelStatic,
+  modelSuspense,
   modelAnimated,
 ];
 

--- a/src/experiments/model_animated/index.js
+++ b/src/experiments/model_animated/index.js
@@ -118,7 +118,7 @@ export default {
   id: 'model_test',
   component: ModelTest,
   metadata: {
-    name: 'Model Animated',
+    name: 'Model Animated (SUSPENSE)',
     author: '',
     description:
       'Loads (large) animated dragon using React.Suspense and external .glb files. Model credit: elly77ellison on sketchfab',

--- a/src/experiments/model_animated/index.js
+++ b/src/experiments/model_animated/index.js
@@ -118,7 +118,7 @@ export default {
   id: 'model_test',
   component: ModelTest,
   metadata: {
-    name: 'Model(ANIMATED)',
+    name: 'Model Animated',
     author: '',
     description:
       'Loads (large) animated dragon using React.Suspense and external .glb files. Model credit: elly77ellison on sketchfab',

--- a/src/experiments/model_static/index.js
+++ b/src/experiments/model_static/index.js
@@ -1,43 +1,39 @@
-import React, { Suspense, useRef } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 
-import { useLoader, useFrame } from 'react-three-fiber';
+import { useFrame } from 'react-three-fiber';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader';
 
 import model_static from '../../models/mario.glb';
 
 const Model = ({ fileRef }) => {
-  const modelRef = useRef();
+  const [modelRender, setModelRender] = useState(null);
 
-  const gltf = useLoader(GLTFLoader, fileRef);
+  useEffect(() => {
+    const loader = new GLTFLoader();
+    try {
+      loader.load(fileRef, gltf => {
+        const modelPos = [0, 0, 0];
+        const modelScale = [0.05, 0.05, 0.05];
+        setModelRender(
+          <group position={modelPos} scale={modelScale}>
+            <primitive object={gltf.scene} />
+          </group>
+        );
+      });
+    } catch (e) {
+      console.log(`GLTFLoader error ${e}`);
+    }
+  }, [fileRef]);
 
-  useFrame(() => {
-    modelRef.current.rotation.y += 0.02;
-  });
-
-  // Mario model is huuuge
-  const modelPos = [0, 20, -100];
-  const modelScale = [0.05, 0.05, 0.05];
-
-  return (
-    <group ref={modelRef} position={modelPos} scale={modelScale}>
-      <primitive object={gltf.scene} />
-    </group>
-  );
-};
-
-// Basic spinning cube loader to display in Suspense
-const Loader = () => {
-  return (
-    <mesh>
-      <boxBufferGeometry attach="geometry" args={[1, 1, 1]} />
-      <meshStandardMaterial attach="material" transparent opacity={0.5} />
-    </mesh>
-  );
+  return <React.Fragment>{modelRender}</React.Fragment>;
 };
 
 export const ModelStatic = () => {
   const modelFile = model_static;
-
+  const modelRef = useRef();
+  useFrame(() => {
+    modelRef.current.rotation.y += 0.02;
+  });
   return (
     <group>
       <ambientLight color="#FFF" intensity={0.5} />
@@ -53,9 +49,9 @@ export const ModelStatic = () => {
         receiveShadow
       />
 
-      <Suspense fallback={<Loader />}>
+      <group ref={modelRef} position={[0, 20, -100]}>
         <Model fileRef={modelFile} />
-      </Suspense>
+      </group>
     </group>
   );
 };
@@ -64,9 +60,22 @@ export default {
   id: 'model_static',
   component: ModelStatic,
   metadata: {
-    name: 'Model(STATIC)',
+    name: 'Model Static',
     author: '',
     description:
-      'Loads static model of Mario using React.Suspense and external .glb files. Model credit: Captain LowPoly on sketchfab',
+      'Loads static model of Mario from an external .glb file w/o using React.Suspense. Model credit: Captain LowPoly on sketchfab',
   },
 };
+
+/* Loader Notes
+
+  Rather than using the useLoader hook and React.suspense we load the model directly with the GLTF loader.
+  The loader is called in a useEffect hook based on the fileRef (which should never change, if it did change it should automatically reload and update).
+  The returned component is initially an empty fragment but updated via a useState hook once the loader is complete.
+  Key to note that R3F is fragment friendly.
+
+  Initially I tried doing all of this with async/await and got into a bind with components as promises. There may have been a way around that but this feels cleaner for a single model.
+
+  Bonus: Removing suspense fixes are repeat load missing model issue.
+  
+*/

--- a/src/experiments/model_suspense/index.js
+++ b/src/experiments/model_suspense/index.js
@@ -1,0 +1,72 @@
+import React, { Suspense, useRef } from 'react';
+
+import { useLoader, useFrame } from 'react-three-fiber';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader';
+
+import model_static from '../../models/mario.glb';
+
+const Model = ({ fileRef }) => {
+  const modelRef = useRef();
+
+  const gltf = useLoader(GLTFLoader, fileRef);
+
+  useFrame(() => {
+    modelRef.current.rotation.y += 0.02;
+  });
+
+  // Mario model is huuuge
+  const modelPos = [0, 20, -100];
+  const modelScale = [0.05, 0.05, 0.05];
+
+  return (
+    <group ref={modelRef} position={modelPos} scale={modelScale}>
+      <primitive object={gltf.scene} />
+    </group>
+  );
+};
+
+// Basic spinning cube loader to display in Suspense
+const Loader = () => {
+  return (
+    <mesh>
+      <boxBufferGeometry attach="geometry" args={[1, 1, 1]} />
+      <meshStandardMaterial attach="material" transparent opacity={0.5} />
+    </mesh>
+  );
+};
+
+export const ModelSuspense = () => {
+  const modelFile = model_static;
+
+  return (
+    <group>
+      <ambientLight color="#FFF" intensity={0.5} />
+      <spotLight
+        color="#FFF"
+        intensity={1.0}
+        position={[0, 20, 100]}
+        angle={0.53}
+        penumbra={0.75}
+        shadow-mapSize-width={2048}
+        shadow-mapSize-height={2048}
+        castShadow
+        receiveShadow
+      />
+
+      <Suspense fallback={<Loader />}>
+        <Model fileRef={modelFile} />
+      </Suspense>
+    </group>
+  );
+};
+
+export default {
+  id: 'model_suspense',
+  component: ModelSuspense,
+  metadata: {
+    name: 'Model Static (SUSPENSE)',
+    author: '',
+    description:
+      'Loads static model of Mario using React.Suspense and external .glb files. Model credit: Captain LowPoly on sketchfab',
+  },
+};

--- a/src/helpers/GLTFPromiseLoader.js
+++ b/src/helpers/GLTFPromiseLoader.js
@@ -1,0 +1,6 @@
+import promisifyLoader from './promiseLoader';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader';
+
+const GLTFPromiseLoader = promisifyLoader(new GLTFLoader());
+
+export default GLTFPromiseLoader;

--- a/src/helpers/promiseLoader.js
+++ b/src/helpers/promiseLoader.js
@@ -1,0 +1,15 @@
+// This function takes any three.js loader and returns a promisifiedLoader
+const promisifyLoader = (loader, onProgress) => {
+  function promiseLoader(url) {
+    return new Promise((resolve, reject) => {
+      loader.load(url, resolve, onProgress, reject);
+    });
+  }
+
+  return {
+    originalLoader: loader,
+    load: promiseLoader,
+  };
+};
+
+export default promisifyLoader;


### PR DESCRIPTION
**Loader Notes**

* Rather than using the useLoader hook and React.suspense we load the model directly with the GLTF loader.
* The loader is called in a useEffect hook based on the fileRef (which should never change, if it did change it should automatically reload and update).
* The returned component is initially an empty fragment but updated via a useState hook once the loader is complete.
* Key to note that R3F is fragment friendly.

  Initially I tried doing all of this with async/await and got into a bind with components as promises. There may have been a way around that but this feels cleaner for a single model.

  **Bonus: Removing suspense fixes are repeat load missing model issue.**
  